### PR TITLE
Delay mode hooks when opening unvisited files

### DIFF
--- a/noccur.el
+++ b/noccur.el
@@ -6,7 +6,7 @@
 ;; Keywords: convenience
 ;; Version: 0.2
 ;; Package: noccur
-;; Package-Requires: ()
+;; Package-Requires: ((emacs "24.4"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -69,7 +69,8 @@ ls-files' and 'grep'."
          (command (format "%s | xargs -0 grep -l \"%s\""
                           listing-command
                           regexp)))
-    (split-string (shell-command-to-string command) "\n")))
+    (cl-remove-if #'string-empty-p
+                  (split-string (shell-command-to-string command) "\n"))))
 
 (provide 'noccur)
 ;;; noccur.el ends here


### PR DESCRIPTION
This PR makes `noccur` run faster on a project that contains a large number of files using the same technique as used in the following discussion:

https://github.com/alphapapa/org-ql/issues/88#issuecomment-570568341

When you open a file using `find-file-noselect`, it runs mode hooks, which can slows down the performance and also sometimes produce annoying error messages.

When you search through buffers, you usually need only syntax highlighting, so there won't be a problem in delaying the mode hooks.